### PR TITLE
change_name_format: dots to underscores

### DIFF
--- a/pkg/telemetry/init.go
+++ b/pkg/telemetry/init.go
@@ -11,8 +11,8 @@ import (
 
 const (
 	logFmt           = "[%s.%s]"
-	metricsFmt       = "%s.%s"
-	metricsPrefixFmt = "%s.%s.%s"
+	metricsFmt       = "%s_%s"
+	metricsPrefixFmt = "%s_%s_%s"
 
 	metricsPrefixEnv = "METRICS_PREFIX"
 	metricsDefault   = "go_app_telemetry"

--- a/pkg/telemetry/method.go
+++ b/pkg/telemetry/method.go
@@ -34,10 +34,10 @@ func NewMethod(methodName, serviceName string) *Method {
 	return &Method{
 		logName:       fmt.Sprintf(logFmt, serviceName, methodName),
 		metricsPrefix: getMetricsName(methodName, serviceName),
-		errorPrefix:   getMetricsName(fmt.Sprintf("%s.error", snakeCaseMethodName), snakeCaseServiceName),
-		successPrefix: getMetricsName(fmt.Sprintf("%s.success", snakeCaseMethodName), snakeCaseServiceName),
-		requestPrefix: getMetricsName(fmt.Sprintf("%s.request", snakeCaseMethodName), snakeCaseServiceName),
-		latencyPrefix: getMetricsName(fmt.Sprintf("%s.latency", snakeCaseMethodName), snakeCaseServiceName),
+		errorPrefix:   getMetricsName(fmt.Sprintf("%s_error", snakeCaseMethodName), snakeCaseServiceName),
+		successPrefix: getMetricsName(fmt.Sprintf("%s_success", snakeCaseMethodName), snakeCaseServiceName),
+		requestPrefix: getMetricsName(fmt.Sprintf("%s_request", snakeCaseMethodName), snakeCaseServiceName),
+		latencyPrefix: getMetricsName(fmt.Sprintf("%s_latency", snakeCaseMethodName), snakeCaseServiceName),
 	}
 }
 
@@ -93,7 +93,7 @@ func (m *Method) SetGauge(value float64, dimension ...string) {
 
 func getMetricsName(methodName, serviceName string) string {
 	if metricsPrefix == "" {
-		return fmt.Sprintf("%s.%s", utils.ToSnakeCase(serviceName), utils.ToSnakeCase(methodName))
+		return fmt.Sprintf(metricsFmt, utils.ToSnakeCase(serviceName), utils.ToSnakeCase(methodName))
 	}
 
 	return fmt.Sprintf(metricsPrefixFmt, metricsPrefix, utils.ToSnakeCase(serviceName), utils.ToSnakeCase(methodName))


### PR DESCRIPTION
## Background
The go-telemetry package right now uses dot(".") as the separator but that is invalid for Prometheus.
<img width="782" height="265" alt="image" src="https://github.com/user-attachments/assets/26ac53a0-e719-404c-9a92-95c425fd2928" />

## Changes
- The format for metric name is changed to use underscores("_") instead of dots(".") in init.go and method.go.

## Tests
All previous tests are passed successfully. No new tests are needed as there is no new functionality.
<img width="449" height="18" alt="image" src="https://github.com/user-attachments/assets/6267bb9f-113c-4294-ba34-716f0261c781" />
