### PR TITLE
Add support of different separators

### DIFF
--- a/internal/metrics/console.go
+++ b/internal/metrics/console.go
@@ -6,6 +6,9 @@ import (
 
 type ConsoleMetrics struct{}
 
+func (c *ConsoleMetrics) Separator() string {
+	return "_"
+}
 func (c *ConsoleMetrics) IncCounter(metric string) {
 	fmt.Printf("Metric: %s, Value: %d\n", metric, 1)
 }

--- a/internal/metrics/noop.go
+++ b/internal/metrics/noop.go
@@ -2,6 +2,9 @@ package metrics
 
 type NoopMetrics struct{}
 
+func (n *NoopMetrics) Separator() string {
+	return ""
+}
 func (n *NoopMetrics) IncCounter(metric string)             {}
 func (n *NoopMetrics) Observe(metric string, value float64) {}
 func (n *NoopMetrics) SetGauge(metric string, value float64) {}

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -42,6 +42,9 @@ func NewPrometheusMetrics(address string) *PrometheusMetrics {
 	}
 }
 
+func (p *PrometheusMetrics) Separator() string {
+	return "_"
+}
 func (p *PrometheusMetrics) IncCounter(metric string) {
 	p.createCounterIfDoesntExist(metric)
 	p.counterByName[metric].Inc()

--- a/internal/utils/strings.go
+++ b/internal/utils/strings.go
@@ -15,6 +15,6 @@ func ToSnakeCase(input string) string {
 }
 
 
-func JoinWithPrefix(prefix string, parts ...string) string {
-    return strings.Join(append([]string{prefix}, parts...), ".")
+func JoinWithPrefix(prefix string, separator string, parts ...string) string {
+    return strings.Join(append([]string{prefix}, parts...), separator)
 }

--- a/pkg/telemetry/method.go
+++ b/pkg/telemetry/method.go
@@ -18,7 +18,7 @@ type Method struct {
 }
 
 type MetricsEmitter interface {
-	// returns the separator used in metrics names
+	// Separator returns the separator used in metrics names
 	// for example, "." or "_"
 	Separator() string
 	IncCounter(metric string)


### PR DESCRIPTION
## Background 
Prometheus is not friendly with metrics name which contains **.** 

## Changes 
For resolving an issue this PR adds a functionality which set separator based on metrics provider 

## Testing
Local testing 