### PR TITLE
Increment Counter by values more than 1

### DIFF
--- a/internal/metrics/console.go
+++ b/internal/metrics/console.go
@@ -9,8 +9,13 @@ type ConsoleMetrics struct{}
 func (c *ConsoleMetrics) Separator() string {
 	return "_"
 }
+
 func (c *ConsoleMetrics) IncCounter(metric string) {
 	fmt.Printf("Metric: %s, Value: %d\n", metric, 1)
+}
+
+func (c *ConsoleMetrics) IncCounterBy(metric string, value float64) {
+	fmt.Printf("Metric: %s, Value: %f\n", metric, value)
 }
 
 func (c *ConsoleMetrics) Observe(metric string, value float64) {

--- a/internal/metrics/noop.go
+++ b/internal/metrics/noop.go
@@ -5,6 +5,7 @@ type NoopMetrics struct{}
 func (n *NoopMetrics) Separator() string {
 	return ""
 }
-func (n *NoopMetrics) IncCounter(metric string)             {}
-func (n *NoopMetrics) Observe(metric string, value float64) {}
-func (n *NoopMetrics) SetGauge(metric string, value float64) {}
+func (n *NoopMetrics) IncCounter(metric string)                  {}
+func (n *NoopMetrics) IncCounterBy(metric string, value float64) {}
+func (n *NoopMetrics) Observe(metric string, value float64)      {}
+func (n *NoopMetrics) SetGauge(metric string, value float64)     {}

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -15,9 +15,9 @@ type PrometheusMetrics struct {
 
 	summaryByName map[string]prometheus.Summary
 	summaryRWMux  sync.RWMutex
-	
-	gaugeByName   map[string]prometheus.Gauge
-	gaugeRWMux    sync.RWMutex
+
+	gaugeByName map[string]prometheus.Gauge
+	gaugeRWMux  sync.RWMutex
 }
 
 func NewPrometheusMetrics(address string) *PrometheusMetrics {
@@ -37,18 +37,24 @@ func NewPrometheusMetrics(address string) *PrometheusMetrics {
 		summaryByName: make(map[string]prometheus.Summary),
 		summaryRWMux:  sync.RWMutex{},
 
-		gaugeByName:   make(map[string]prometheus.Gauge),
-		gaugeRWMux:    sync.RWMutex{},
+		gaugeByName: make(map[string]prometheus.Gauge),
+		gaugeRWMux:  sync.RWMutex{},
 	}
 }
 
 func (p *PrometheusMetrics) Separator() string {
 	return "_"
 }
+
 func (p *PrometheusMetrics) IncCounter(metric string) {
 	p.createCounterIfDoesntExist(metric)
 	p.counterByName[metric].Inc()
 
+}
+
+func (p *PrometheusMetrics) IncCounterBy(metric string, value float64) {
+	p.createCounterIfDoesntExist(metric)
+	p.counterByName[metric].Add(value)
 }
 
 func (p *PrometheusMetrics) Observe(metric string, value float64) {

--- a/internal/utils/strings.go
+++ b/internal/utils/strings.go
@@ -1,20 +1,20 @@
 package utils
+
 import (
-    "regexp"
-    "strings"
+	"regexp"
+	"strings"
 )
 
 // ToSnakeCase converts "MyMethodName" or "myMethodName" to "my_method_name"
 func ToSnakeCase(input string) string {
-    var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
-    var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+	var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+	var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
 
-    snake := matchFirstCap.ReplaceAllString(input, "${1}_${2}")
-    snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
-    return strings.ToLower(snake)
+	snake := matchFirstCap.ReplaceAllString(input, "${1}_${2}")
+	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
+	return strings.ToLower(snake)
 }
 
-
 func JoinWithPrefix(prefix string, separator string, parts ...string) string {
-    return strings.Join(append([]string{prefix}, parts...), separator)
+	return strings.Join(append([]string{prefix}, parts...), separator)
 }

--- a/internal/utils/strings_test.go
+++ b/internal/utils/strings_test.go
@@ -3,17 +3,17 @@ package utils
 import "testing"
 
 func TestToSnakeCase(t *testing.T) {
-    tests := map[string]string{
-        "MyMethodName":    "my_method_name",
-        "simpleTest":      "simple_test",
-        "HTTPRequest":     "http_request",
-        "GetURLParams":    "get_url_params",
-        "IDNumberCheck":   "id_number_check",
-    }
+	tests := map[string]string{
+		"MyMethodName":  "my_method_name",
+		"simpleTest":    "simple_test",
+		"HTTPRequest":   "http_request",
+		"GetURLParams":  "get_url_params",
+		"IDNumberCheck": "id_number_check",
+	}
 
-    for input, expected := range tests {
-        if result := ToSnakeCase(input); result != expected {
-            t.Errorf("ToSnakeCase(%q) = %q; want %q", input, result, expected)
-        }
-    }
+	for input, expected := range tests {
+		if result := ToSnakeCase(input); result != expected {
+			t.Errorf("ToSnakeCase(%q) = %q; want %q", input, result, expected)
+		}
+	}
 }

--- a/pkg/telemetry/method.go
+++ b/pkg/telemetry/method.go
@@ -55,10 +55,8 @@ func (m *Method) LogAndCountErrorOrSuccess(err error, dimension ...string) {
 	if err != nil {
 		m.LogAndCountError(err, dimension...)
 		return
-
 	}
 	m.LogAndCountSuccess(dimension...)
-
 }
 
 func (m *Method) LogAndCountSuccess(dimension ...string) {
@@ -93,6 +91,9 @@ func (m *Method) IncCounter(dimension ...string) {
 
 func (m *Method) IncCounterBy(value float64, dimension ...string) {
 	metric := utils.JoinWithPrefix(m.metricsPrefix, metricsEmitter.Separator(), dimension...)
+	if value <= 0 {
+		return
+	}
 	metricsEmitter.IncCounterBy(metric, value)
 }
 

--- a/pkg/telemetry/method.go
+++ b/pkg/telemetry/method.go
@@ -22,6 +22,7 @@ type MetricsEmitter interface {
 	// for example, "." or "_"
 	Separator() string
 	IncCounter(metric string)
+	IncCounterBy(metric string, value float64)
 	Observe(metric string, value float64)
 	SetGauge(metric string, value float64)
 }
@@ -88,6 +89,11 @@ func (m *Method) CountSuccess(dimension ...string) {
 func (m *Method) IncCounter(dimension ...string) {
 	metric := utils.JoinWithPrefix(m.metricsPrefix, metricsEmitter.Separator(), dimension...)
 	metricsEmitter.IncCounter(metric)
+}
+
+func (m *Method) IncCounterBy(value float64, dimension ...string) {
+	metric := utils.JoinWithPrefix(m.metricsPrefix, metricsEmitter.Separator(), dimension...)
+	metricsEmitter.IncCounterBy(metric, value)
 }
 
 func (m *Method) SetGauge(value float64, dimension ...string) {


### PR DESCRIPTION
### Description
This pull request adds support for incrementing counters by arbitrary values (not just by 1) across the metrics subsystem. 

### Changes
The changes introduce a new `IncCounterBy` method to the `MetricsEmitter` interface and its implementations, and expose this functionality in the `Method` type. Minor code cleanups are also included.

**Metrics subsystem enhancements:**

* Added `IncCounterBy(metric string, value float64)` to the `MetricsEmitter` interface in `pkg/telemetry/method.go`, allowing counters to be incremented by a specified value.
* Implemented the new `IncCounterBy` method for all metrics backends:
  * `PrometheusMetrics` in `internal/metrics/prometheus.go` now supports incrementing counters by arbitrary values.
  * `ConsoleMetrics` in `internal/metrics/console.go` now prints the incremented value for `IncCounterBy`.
  * `NoopMetrics` in `internal/metrics/noop.go` adds a no-op implementation for `IncCounterBy`.
* Exposed `IncCounterBy` in the `Method` type in `pkg/telemetry/method.go`, allowing callers to increment counters by custom values with dimensions.

**Code cleanup:**

* Minor whitespace and import formatting adjustments in `internal/utils/strings.go`. [[1]](diffhunk://#diff-3cb54bbd9978ec197cf07a8b7c9ce74ee93ac512c1d5d22f2ca0f9090ff4d4faR2) [[2]](diffhunk://#diff-3cb54bbd9978ec197cf07a8b7c9ce74ee93ac512c1d5d22f2ca0f9090ff4d4faL17)

### Tests
Tested on local dummy application.